### PR TITLE
fix: package lock serverless-build 1.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6821,9 +6821,9 @@
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
     "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -6927,11 +6927,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "requires": {
-        "call-bind": "^1.0.0"
+        "call-bind": "^1.0.2"
       }
     },
     "is-windows": {
@@ -9415,9 +9415,9 @@
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -10133,9 +10133,9 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -10768,14 +10768,13 @@
       }
     },
     "serverless-esbuild": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/serverless-esbuild/-/serverless-esbuild-1.20.0.tgz",
-      "integrity": "sha512-n9HO40Mt4CE7buWAEaww45hr7aeYNbSHYiY6eXOpk1ZxwWzD+PdnmbkiE5wqsvXq6aPDkcBDB4NPTHPXnn7ejw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/serverless-esbuild/-/serverless-esbuild-1.25.0.tgz",
+      "integrity": "sha512-n/ztyc8kZIZV70PK/RHXISENhgl2e6Zxj876QIXFsJQAv97Vnwa4wBMsTb3AHcLdx1WxJcRFp+uf/gHkpn0wjg==",
       "requires": {
         "archiver": "^5.3.0",
         "bestzip": "^2.2.0",
         "chokidar": "^3.4.3",
-        "esbuild": ">=0.8",
         "fs-extra": "^9.0.1",
         "globby": "^11.0.1",
         "p-map": "^4.0.0",
@@ -10796,9 +10795,9 @@
           }
         },
         "ramda": {
-          "version": "0.27.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.2.tgz",
+          "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
         },
         "semver": {
           "version": "7.3.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jest": "^27.2.4",
     "nock": "^13.1.3",
     "serverless": "2.17.0",
-    "serverless-esbuild": "^1.20.0",
+    "serverless-esbuild": "1.25.0",
     "serverless-iam-roles-per-function": "^3.2.0",
     "serverless-plugin-split-stacks": "^1.11.2",
     "serverless-prune-plugin": "^1.6.0",


### PR DESCRIPTION
# [INFRA]

## What changes does this PR introduce

- [] Feature
- [X] Bug

Fixed the serverless-build version to version 1.25.0 due to a break change in version 1.26 that updates the serverless logs.
