### PR TITLE
feat: add custom plugin for sns delivery metrics to cloudwatch after deploy when there are topics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,9 +1932,9 @@
       }
     },
     "@taxdown/eslint-config": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@taxdown/eslint-config/-/eslint-config-0.1.12.tgz",
-      "integrity": "sha512-Tkww8bahfRInwZRcFlUJXfJa4GWHNyIyJxCuluwLy3fAI1ZKpyf3gsKBPFHlBQOkHJo0iO6nCX5xjJv1c2vocw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@taxdown/eslint-config/-/eslint-config-1.0.0.tgz",
+      "integrity": "sha512-5gsNN4bOcgQvy+GP9BQmK57igguT974g5RqhZ29DQEAIAd4Y1Q3qGpTiIOWOTC41Sp/mRU2dWI7JaRK/nBSRRQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.10",
@@ -1945,6 +1945,7 @@
         "eslint": "^7.16.0",
         "eslint-config-prettier": "^7.1.0",
         "eslint-import-resolver-babel-module": "^5.2.0",
+        "eslint-plugin-jest": "^26.1.0",
         "eslint-plugin-prettier": "^3.3.0",
         "prettier": "^2.2.1",
         "typescript": "^4.1.3"
@@ -2090,9 +2091,9 @@
       }
     },
     "@types/json-schema": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
+      "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
       "dev": true
     },
     "@types/keyv": {
@@ -2293,6 +2294,78 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.16.0.tgz",
+      "integrity": "sha512-iYej2ER6AwmejLWMWzJIHy3nPJeGDuCqf8Jnb+jAQVoPpmWzwQOfa9hWVB8GIQE5gsCv/rfN4T+AYb/V06WseQ==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.16.0",
+        "@typescript-eslint/types": "5.16.0",
+        "@typescript-eslint/typescript-estree": "5.16.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.16.0.tgz",
+          "integrity": "sha512-P+Yab2Hovg8NekLIR/mOElCDPyGgFZKhGoZA901Yax6WR6HVeGLbsqJkZ+Cvk5nts/dAlFKm8PfL43UZnWdpIQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.16.0",
+            "@typescript-eslint/visitor-keys": "5.16.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.16.0.tgz",
+          "integrity": "sha512-oUorOwLj/3/3p/HFwrp6m/J2VfbLC8gjW5X3awpQJ/bSG+YRGFS4dpsvtQ8T2VNveV+LflQHjlLvB6v0R87z4g==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.16.0.tgz",
+          "integrity": "sha512-SE4VfbLWUZl9MR+ngLSARptUv2E8brY0luCdgmUevU6arZRY/KxYoLI/3V/yxaURR8tLRN7bmZtJdgmzLHI6pQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.16.0",
+            "@typescript-eslint/visitor-keys": "5.16.0",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.16.0.tgz",
+          "integrity": "sha512-jqxO8msp5vZDhikTwq9ubyMHqZ67UIvawohr4qF3KhlpL7gzSjOd+8471H3nh5LyABkaI85laEKKU8SnGUK5/g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.16.0",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+          "dev": true
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5266,6 +5339,15 @@
       "requires": {
         "pkg-up": "^3.1.0",
         "resolve": "^1.20.0"
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.2.tgz",
+      "integrity": "sha512-1bXCoRODPkGN06n9KAMls4Jm0eyS+0Q/LWcIxhqWR2ycV0Z7lnx2c10idk4dtFIJY5xStgiIr5snC6/rxcXpbw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "^5.10.0"
       }
     },
     "eslint-plugin-prettier": {
@@ -9832,9 +9914,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
-      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -10277,9 +10359,9 @@
       "dev": true
     },
     "reselect": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@commitlint/cli": "^13.2.0",
     "@commitlint/config-conventional": "^13.2.0",
-    "@taxdown/eslint-config": "^0.1.12",
+    "@taxdown/eslint-config": "^1.0.0",
     "@types/serverless": "^1.78.35",
     "eslint": "^7.32.0",
     "husky": "^7.0.0",

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -41,6 +41,9 @@ describe('Test CustomConfig', () => {
       },
     };
     const customConfig = new CustomConfig(service);
+    expect(customConfig.isEsLogs()).toBe(true);
+    expect(customConfig.isSnsDeliveryLog()).toBe(true);
+    expect(customConfig.isSplitStacks()).toBe(true);
     expect(customConfig.get()).toEqual({
       esbuild: {
         concurrency: 10,
@@ -60,6 +63,55 @@ describe('Test CustomConfig', () => {
         automatic: true,
         number: 10,
       },
+      snsDeliveryLog: true,
+      splitStacks: {
+        custom: 'test/.serverless/stacks-map.js',
+        perFunction: false,
+        perType: false,
+        perGroupFunction: false,
+        stackConcurrency: 5,
+      },
+    });
+  });
+  test('When snsDeliveryLog is set to false, it should return that key as false and the function as well', async () => {
+    const service = {
+      custom: {
+        esLogs: {
+          endpoint: 'testEndpoint',
+          index: 'test',
+        },
+        snsDeliveryLog: false,
+        splitStacks: {},
+      },
+      functions: [],
+      serverless: {
+        config: {
+          servicePath: 'test',
+        },
+      },
+    };
+    const customConfig = new CustomConfig(service);
+    expect(customConfig.isSnsDeliveryLog()).toBe(false);
+    expect(customConfig.get()).toEqual({
+      esbuild: {
+        concurrency: 10,
+        exclude: ['aws-sdk'],
+        format: 'cjs',
+        sourcemap: 'external',
+      },
+      esLogs: {
+        endpoint: 'testEndpoint',
+        index: 'test',
+        indexDateSeparator: '-',
+        useDefaultRole: true,
+        includeApiGWLogs: true,
+        mergeFunctionPolicies: true,
+      },
+      prune: {
+        automatic: true,
+        number: 10,
+      },
+      snsDeliveryLog: false,
       splitStacks: {
         custom: 'test/.serverless/stacks-map.js',
         perFunction: false,
@@ -108,6 +160,7 @@ describe('Test CustomConfig', () => {
         automatic: true,
         number: 10,
       },
+      snsDeliveryLog: true,
       splitStacks: {
         custom: 'test/.serverless/stacks-map.js',
         perFunction: false,
@@ -138,6 +191,7 @@ describe('Test CustomConfig', () => {
       },
     };
     const customConfig = new CustomConfig(service);
+    expect(customConfig.isSplitStacks()).toBe(false);
     expect(customConfig.get()).toEqual({
       esbuild: {
         concurrency: 10,
@@ -157,6 +211,7 @@ describe('Test CustomConfig', () => {
         automatic: true,
         number: 10,
       },
+      snsDeliveryLog: true,
     });
   });
   test('When functions an empty object (default value), it should not have the split stacks output', async () => {
@@ -176,6 +231,7 @@ describe('Test CustomConfig', () => {
       },
     };
     const customConfig = new CustomConfig(service);
+    expect(customConfig.isSplitStacks()).toBe(false);
     expect(customConfig.get()).toEqual({
       esbuild: {
         concurrency: 10,
@@ -195,6 +251,7 @@ describe('Test CustomConfig', () => {
         automatic: true,
         number: 10,
       },
+      snsDeliveryLog: true,
     });
   });
   test('When no functions, it should not have the split stacks output', async () => {
@@ -213,6 +270,7 @@ describe('Test CustomConfig', () => {
       },
     };
     const customConfig = new CustomConfig(service);
+    expect(customConfig.isSplitStacks()).toBe(false);
     expect(customConfig.get()).toEqual({
       esbuild: {
         concurrency: 10,
@@ -232,6 +290,7 @@ describe('Test CustomConfig', () => {
         automatic: true,
         number: 10,
       },
+      snsDeliveryLog: true,
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ const DEFAULT_CONFIG = {
     automatic: true,
     number: 10,
   },
+  snsDeliveryLog: true,
   splitStacks: {
     custom: undefined,
     perFunction: false,
@@ -40,6 +41,7 @@ export class CustomConfig {
       esbuild: { ...options?.esbuild, ...DEFAULT_CONFIG.esbuild },
       esLogs: this.buildEsLogsOptions(service),
       prune: { ...options?.prune, ...DEFAULT_CONFIG.prune },
+      snsDeliveryLog: options?.snsDeliveryLog ?? DEFAULT_CONFIG.snsDeliveryLog,
       splitStacks: this.buildStackMapOptions(service),
     };
   }
@@ -107,6 +109,9 @@ export class CustomConfig {
   }
   isEsLogs(): boolean {
     return this.isEsLogsEnabled;
+  }
+  isSnsDeliveryLog(): boolean {
+    return this.options.snsDeliveryLog;
   }
   isSplitStacks(): boolean {
     return this.isSplitStacksEnabled;

--- a/src/plugin.spec.ts
+++ b/src/plugin.spec.ts
@@ -28,7 +28,7 @@ describe('Test ServerlessBuildPlugin', () => {
       },
     } as unknown as Serverless;
     const plugin = new ServerlessBuildPlugin(serverless);
-    expect(addPlugin).toHaveBeenCalledTimes(5);
+    expect(addPlugin).toHaveBeenCalledTimes(6);
   });
   test('When creating the serverless build plugin, with no functions, it should not add the stacksMap plugin, and hook should not call createStackMap', async () => {
     const addPlugin = jest.fn();
@@ -58,7 +58,7 @@ describe('Test ServerlessBuildPlugin', () => {
     } as unknown as Serverless;
     const plugin = new ServerlessBuildPlugin(serverless);
     plugin.hooks['after:package:initialize']();
-    expect(addPlugin).toHaveBeenCalledTimes(5);
+    expect(addPlugin).toHaveBeenCalledTimes(6);
   });
   test('When creating the serverless build plugin, it should add all plugins', async () => {
     const addPlugin = jest.fn();
@@ -85,6 +85,6 @@ describe('Test ServerlessBuildPlugin', () => {
       },
     } as unknown as Serverless;
     const plugin = new ServerlessBuildPlugin(serverless);
-    expect(addPlugin).toHaveBeenCalledTimes(6);
+    expect(addPlugin).toHaveBeenCalledTimes(7);
   });
 });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,6 +8,7 @@ import * as Serverless from 'serverless';
 import * as ServerlessPlugin from 'serverless/classes/Plugin';
 import { CustomConfig } from './config';
 import { ServerlessDisableFunctionPlugin } from './plugin/disable';
+import { ServerlessSnsDeliveryLogPlugin } from './plugin/snsDeliveryLog/snsDeliveryLog';
 
 export class ServerlessBuildPlugin implements ServerlessPlugin {
   customConfig: CustomConfig;
@@ -27,6 +28,9 @@ export class ServerlessBuildPlugin implements ServerlessPlugin {
     serverless.pluginManager.addPlugin(ServerlessIamPerFunctionPlugin);
     if (this.customConfig.isSplitStacks()) {
       serverless.pluginManager.addPlugin(ServerlessPluginSplitStacks);
+    }
+    if (this.customConfig.isSnsDeliveryLog()) {
+      serverless.pluginManager.addPlugin(ServerlessSnsDeliveryLogPlugin);
     }
 
     this.hooks = {

--- a/src/plugin/snsDeliveryLog/role.ts
+++ b/src/plugin/snsDeliveryLog/role.ts
@@ -1,0 +1,38 @@
+export const iamRole = {
+  Type: 'AWS::IAM::Role',
+  Properties: {
+    AssumeRolePolicyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: {
+            Service: 'sns.amazonaws.com',
+          },
+          Action: 'sts:AssumeRole',
+        },
+      ],
+    },
+    Policies: [
+      {
+        PolicyName: 'ServerlessSnsDeliveryLogIAMPolicy',
+        PolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: [
+                'logs:CreateLogGroup',
+                'logs:CreateLogStream',
+                'logs:PutLogEvents',
+                'logs:PutMetricFilter',
+                'logs:PutRetentionPolicy',
+              ],
+              Resource: 'arn:aws:logs:*:*:*',
+            },
+          ],
+        },
+      },
+    ],
+  },
+};

--- a/src/plugin/snsDeliveryLog/snsDeliveryLog.spec.ts
+++ b/src/plugin/snsDeliveryLog/snsDeliveryLog.spec.ts
@@ -1,0 +1,125 @@
+import Serverless from 'serverless';
+import { ServerlessSnsDeliveryLogPlugin } from './snsDeliveryLog';
+
+describe('Test ServerlessSnsDeliveryLogPlugin', () => {
+  describe('No SNS topic on resources', () => {
+    const serverless = {
+      cli: {
+        log: jest.fn(),
+      },
+      service: {
+        //functions on processed format after initialization
+        functions: {},
+        resources: {
+          Resources: {
+            LambdaFunction: {
+              Type: 'AWS::Lambda::Function',
+            },
+          },
+        },
+      },
+      configSchemaHandler: {
+        defineFunctionProperties: jest.fn(),
+      },
+    } as unknown as Serverless;
+    Object.freeze(serverless);
+    test.only('When package is befor finalize, ensure isSnsTopics is false', async () => {
+      const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
+      await plugin.hooks['before:package:finalize']();
+      //@ts-expect-error
+      expect(plugin.isSnsTopics).toBe(false);
+    });
+    test.only('When package is finalized, ensure there are no custom resource', async () => {
+      const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
+      await plugin.hooks['before:package:finalize']();
+      await plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
+      expect(serverless.service.provider).toBeUndefined();
+      // await plugin.hooks['after:deploy:deploy']();
+    });
+    test.only('When we have finished deploy, do nothing', async () => {
+      const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
+      await plugin.hooks['before:package:finalize']();
+      await plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
+      await plugin.hooks['after:deploy:deploy']();
+      expect(serverless.service.provider).toBeUndefined();
+    });
+  });
+  describe('One sns topic on resources', () => {
+    const serverless = {
+      cli: {
+        log: jest.fn(),
+      },
+      service: {
+        //functions on processed format after initialization
+        functions: {},
+        resources: {
+          Resources: {
+            LambdaFunction: {
+              Type: 'AWS::SNS::Topic',
+            },
+          },
+        },
+        provider: {
+          compiledCloudFormationTemplate: {
+            Resources: {},
+          },
+        },
+      },
+      configSchemaHandler: {
+        defineFunctionProperties: jest.fn(),
+      },
+    } as unknown as Serverless;
+    const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
+    test.only('When finizing package, ensure isSnsTopics is true', async () => {
+      await plugin.hooks['before:package:finalize']();
+      //@ts-expect-error
+      expect(plugin.isSnsTopics).toBe(true);
+    });
+    test.only('When finizing package, ensure LambdaRole is present', async () => {
+      await plugin.hooks['before:package:finalize']();
+      await plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
+      expect(serverless.service.provider).toEqual({
+        compiledCloudFormationTemplate: {
+          Resources: {
+            ServerlessSnsDeliveryLogIamRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: 'sns.amazonaws.com' },
+                      Action: 'sts:AssumeRole',
+                    },
+                  ],
+                },
+                Policies: [
+                  {
+                    PolicyName: 'ServerlessSnsDeliveryLogIAMPolicy',
+                    PolicyDocument: {
+                      Version: '2012-10-17',
+                      Statement: [
+                        {
+                          Effect: 'Allow',
+                          Action: [
+                            'logs:CreateLogGroup',
+                            'logs:CreateLogStream',
+                            'logs:PutLogEvents',
+                            'logs:PutMetricFilter',
+                            'logs:PutRetentionPolicy',
+                          ],
+                          Resource: 'arn:aws:logs:*:*:*',
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/plugin/snsDeliveryLog/snsDeliveryLog.spec.ts
+++ b/src/plugin/snsDeliveryLog/snsDeliveryLog.spec.ts
@@ -23,20 +23,20 @@ describe('Test ServerlessSnsDeliveryLogPlugin', () => {
       },
     } as unknown as Serverless;
     Object.freeze(serverless);
-    test.only('When package is befor finalize, ensure isSnsTopics is false', async () => {
+    test('When package is befor finalize, ensure isSnsTopics is false', async () => {
       const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
       await plugin.hooks['before:package:finalize']();
       //@ts-expect-error
       expect(plugin.isSnsTopics).toBe(false);
     });
-    test.only('When package is finalized, ensure there are no custom resource', async () => {
+    test('When package is finalized, ensure there are no custom resource', async () => {
       const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
       await plugin.hooks['before:package:finalize']();
       await plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
       expect(serverless.service.provider).toBeUndefined();
       // await plugin.hooks['after:deploy:deploy']();
     });
-    test.only('When we have finished deploy, do nothing', async () => {
+    test('When we have finished deploy, do nothing', async () => {
       const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
       await plugin.hooks['before:package:finalize']();
       await plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
@@ -70,12 +70,12 @@ describe('Test ServerlessSnsDeliveryLogPlugin', () => {
       },
     } as unknown as Serverless;
     const plugin = new ServerlessSnsDeliveryLogPlugin(serverless);
-    test.only('When finizing package, ensure isSnsTopics is true', async () => {
+    test('When finizing package, ensure isSnsTopics is true', async () => {
       await plugin.hooks['before:package:finalize']();
       //@ts-expect-error
       expect(plugin.isSnsTopics).toBe(true);
     });
-    test.only('When finizing package, ensure LambdaRole is present', async () => {
+    test('When finizing package, ensure LambdaRole is present', async () => {
       await plugin.hooks['before:package:finalize']();
       await plugin.hooks['aws:package:finalize:mergeCustomProviderResources']();
       expect(serverless.service.provider).toEqual({

--- a/src/plugin/snsDeliveryLog/snsDeliveryLog.ts
+++ b/src/plugin/snsDeliveryLog/snsDeliveryLog.ts
@@ -1,0 +1,101 @@
+import AWS from 'aws-sdk';
+import * as Serverless from 'serverless';
+import * as ServerlessPlugin from 'serverless/classes/Plugin';
+
+import { iamRole } from './role';
+
+const SNS_ATTRIBUTE_ROLE = [
+  'HTTPSuccessFeedbackRoleArn',
+  'HTTPFailureFeedbackRoleArn',
+  'FirehoseSuccessFeedbackRoleArn',
+  'FirehoseFailureFeedbackRoleArn',
+  'LambdaSuccessFeedbackRoleArn',
+  'LambdaFailureFeedbackRoleArn',
+  'ApplicationSuccessFeedbackRoleArn',
+  'ApplicationFailureFeedbackRoleArn',
+  'SQSSuccessFeedbackRoleArn',
+  'SQSFailureFeedbackRoleArn',
+];
+
+const SNS_ATTRIBUTE_SAMPLE_RATE = [
+  'HTTPSuccessFeedbackSampleRate',
+  'FirehoseSuccessFeedbackSampleRate',
+  'LambdaSuccessFeedbackSampleRate',
+  'ApplicationSuccessFeedbackSampleRate',
+  'SQSSuccessFeedbackSampleRate',
+];
+
+export class ServerlessSnsDeliveryLogPlugin implements ServerlessPlugin {
+  hooks: ServerlessPlugin.Hooks;
+  protected isSnsTopics = false;
+  protected readonly roleName = 'ServerlessSnsDeliveryLogIamRole';
+  constructor(protected serverless: Serverless) {
+    this.hooks = {
+      'before:package:finalize': this.checkSnsTopics.bind(this),
+      'aws:package:finalize:mergeCustomProviderResources': this.addSnsIamRole.bind(this),
+      'after:deploy:deploy': this.setSnsDeliveryAttributes.bind(this),
+    };
+  }
+  protected async getIamRoleArn(): Promise<string> {
+    const cloudFormation = new AWS.CloudFormation({
+      region: this.serverless.service.provider.region,
+      apiVersion: '2010-05-15',
+    });
+    const stackName = this.serverless.getProvider('aws').naming.getStackName();
+    const roleResource = await cloudFormation
+      .describeStackResource({ StackName: stackName, LogicalResourceId: this.roleName })
+      .promise();
+    const rolePhysicalId = roleResource.StackResourceDetail.PhysicalResourceId;
+    const iam = new AWS.IAM({ apiVersion: '2010-05-08' });
+    const role = await iam.getRole({ RoleName: rolePhysicalId }).promise();
+    return role.Role.Arn;
+  }
+  async checkSnsTopics(): Promise<void> {
+    for (const resource in this.serverless.service.resources.Resources) {
+      if (this.serverless.service.resources.Resources[resource].Type === 'AWS::SNS::Topic') {
+        this.isSnsTopics = true;
+      }
+    }
+  }
+  async addSnsIamRole(): Promise<void> {
+    if (this.isSnsTopics) {
+      const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+      template.Resources[this.roleName] = iamRole;
+    }
+  }
+  async setSnsDeliveryAttributes(): Promise<void> {
+    if (this.isSnsTopics) {
+      const sns = new AWS.SNS({
+        region: this.serverless.service.provider.region,
+        apiVersion: '2010-03-31',
+      });
+      const roleArn = await this.getIamRoleArn();
+      for (const resource in this.serverless.service.resources.Resources) {
+        if (this.serverless.service.resources.Resources[resource].Type === 'AWS::SNS::Topic') {
+          const topicName =
+            this.serverless.service.resources.Resources[resource].Properties.TopicName;
+          // Should return the topic, since it already exists, instead of creating
+          const topic = await sns.createTopic({ Name: topicName }).promise();
+          // Set role for topic delivery messages
+          for (const attributeRole of SNS_ATTRIBUTE_ROLE) {
+            const params = {
+              AttributeName: attributeRole,
+              TopicArn: topic.TopicArn,
+              AttributeValue: roleArn,
+            };
+            await sns.setTopicAttributes(params).promise();
+          }
+          // Set sample rate for topic delicery messages
+          for (const attributeRole of SNS_ATTRIBUTE_SAMPLE_RATE) {
+            const params = {
+              AttributeName: attributeRole,
+              TopicArn: topic.TopicArn,
+              AttributeValue: '0',
+            };
+            await sns.setTopicAttributes(params).promise();
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# [BACK-1188]

## What changes does this PR introduce

- [X] Feature
  - feat: add custom plugin for sns delivery metrics to cloudwatch after deploy when there are topics
  - feat: upgrade @taxdown/eslint-config to latest

## Any background context you want to provide

Dados los problemas con SNS, he decidido meter este plugin que hace que se seteen las metricas de envio de mensajes a cloudwatch, tanto de exito como de error y asi podamos tener logs de todo.

Esta es la unica manera dado que esas metricas no se pueden configurar desde cloudformation (WTF?)

Probado con Naboo (tiene SNS) y Ryuk (no tiene SNS).